### PR TITLE
Refer to team members instead of CIs

### DIFF
--- a/organization/roles/engineering_manager_role.md
+++ b/organization/roles/engineering_manager_role.md
@@ -4,22 +4,22 @@
 
 - To develop a healthy environment, aligned with [Holaluz values](https://drive.google.com/file/d/15QltL5S1phAQeTl4rlveiT5uoblGQz6f/view) and with the [engineering vision and strategy](../../README.md).
 
-- To ensure that their purpose team has the right people and the right skillset, including [hard and soft skills](https://www.thebalancecareers.com/hard-skills-vs-soft-skills-2063780). In agreement with the CTO, EM has the responsibility to decide hiring and firing. Movement of Individual Contributors (IC) between teams requires an agreement between EMs and Product Owners (PO) of both teams.
+- To ensure that their purpose team has the right people and the right skillset, including [hard and soft skills](https://www.thebalancecareers.com/hard-skills-vs-soft-skills-2063780). In agreement with the CTO, EM has the responsibility to decide hiring and firing. Members switching teams requires an agreement between EMs and Product Owners (PO) of both teams.
 
 - [To be accountable](https://dictionary.cambridge.org/dictionary/english/accountable) for the throughput of the purpose team, where throughput is measured by the given business value, and to work in its continuous improvement. To collaborate with product people, UX, data scientists, and stakeholders to achieve that.
 
 - To deal with conflicts between individuals and engagement and performance issues and execute the necessary actions to solve those problems looking to maximize the benefits for the whole purpose team.
 
-- To work in the career path and personal growth of the ICs, aligning that with the team needs.
+- To work in the career path and personal growth of each team member, aligning it with the needs of the team.
 
-- To ensure salaries are fair with the value given by the IC, fair inside the team, and that they feel fairly paid. In case there's an issue in this topic, ensure that the CTO is aware and have all the necessary information to take the proper actions. The final decision about salaries is the responsibility of the CTO, who ensures consistency between teams and also from a company and market perspective.
+- To ensure salaries are fair with the value provided by each team member, fair within the team, and that they feel fairly paid. In case there's an issue about this topic, ensure that the CTO is aware and has all the necessary information to take the proper actions. The final decision about salaries is the responsibility of the CTO, who ensures consistency between teams and also from a company and market perspective.
 
 - To align themselves with the CTO and other EMs and make sure to transmit to their team a shared direction and strategy, unified and uniform. Each EM should apply the most suitable techniques for each context and situation, but the strategy and the vision are common.
 
-- To ensure that the team have and know their domain and objectives, and have the tools to be sure that it's working and evolving as expected. It includes, but is not limited to, server monitoring, data governance, business functionalities, repositories, alerts, operative maintenance, and security, which they are responsible for.
+- To ensure that the team has and know its domain and goals, and has the tools to be sure that it's working and evolving as expected. It includes, but is not limited to, server monitoring, data governance, business functionalities, repositories, alerts, operative maintenance, and security, which they are responsible for.
 
-- To have experience in developing the IC job and abstraction capability enough to guide and technically challenge the team. To take part in technical decisions and help tiebreaking technical disagreements, besides not necessarily being the technical expert of the team.
+- To have experience in developing the job of each team member and enough abstraction skills to guide and technically challenge the team. To take part in technical decisions and help tiebreaking technical disagreements, besides not necessarily being the technical expert of the team.
 
-- To be very involved in the day-to-day of their team. To actively participate in the work dynamics: plannings, pairings, check PRs, etc., being that their primary workload and keeping enough time to do a good follow-up of the IC and strategical work with the [EMT](../teams/engineering_management_team.md). The balance between both activities might change depending on team needs, but none of them should go under 25% of work time in any case.
+- To be very involved in the day-to-day of their team. To actively participate in the work dynamics: plannings, pairings, check PRs, etc., being that their primary workload and keeping enough time to do a good follow-up of each team member and strategical work with the [EMT](../teams/engineering_management_team.md). The balance between both activities might change depending on team's needs, but none of them should go under 25% of work time in any case.
 
 - We use a [delegation board](https://docs.google.com/spreadsheets/d/1qPaeVO3RSkNdQ9tycSKE3H-oyk-bIciDu-_hw8O8UW0/edit?usp=sharing) to have a precise and shared vision of the delegation levels in specific responsibilities between the CTO and each EM.


### PR DESCRIPTION
I'd rather talk about _team members_ than ICs. On one hand, it doesn't need clarification. And on the other, referring to people as "contributors" strips us of a lot of dimensions and facets. We're not just our contributions nor should we strive to be. On that line, I also think it doesn't align really well to the company's values booklet.

Warning: so far I have only reviewed this article. More commits or even more PRs could possibly ensue this one as I keep going XD